### PR TITLE
[DRAFT] chore: add Keyring Network integration

### DIFF
--- a/src/interfaces/IKeyringChecker.sol
+++ b/src/interfaces/IKeyringChecker.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.5.0;
+
+/// @title Keyring Checker Interface
+/// @notice Interface for a contract that checks credentials against a Keyring contract.
+interface IKeyringChecker {
+    /**
+     * @notice Checks if an entity has a valid credential and supports legacy interface.
+     * @param policyId The ID of the policy.
+     * @param entity The address of the entity to check.
+     * @return True if the entity has a valid credential, false otherwise.
+     */
+    function checkCredential(uint256 policyId, address entity) external view returns (bool);
+}

--- a/src/interfaces/IMetaMorpho.sol
+++ b/src/interfaces/IMetaMorpho.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.5.0;
 import {IMorpho, Id, MarketParams} from "../../lib/morpho-blue/src/interfaces/IMorpho.sol";
 import {IERC4626} from "../../lib/openzeppelin-contracts/contracts/interfaces/IERC4626.sol";
 import {IERC20Permit} from "../../lib/openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Permit.sol";
-
+import {IKeyringChecker} from "../../src/interfaces/IKeyringChecker.sol";
 import {MarketConfig, PendingUint192, PendingAddress} from "../libraries/PendingLib.sol";
 
 struct MarketAllocation {
@@ -74,6 +74,12 @@ interface IMetaMorphoBase {
     /// This difference will decrease the fee accrued until one of the functions updating `lastTotalAssets` is
     /// triggered (deposit/mint/withdraw/redeem/setFee/setFeeRecipient).
     function lastTotalAssets() external view returns (uint256);
+
+    /// @notice The keyring checker address. Address(0) if no keyring checker is set.
+    function keyringChecker() external view returns (IKeyringChecker);
+
+    /// @notice The keyring policy ID used to check if a user is whitelisted.
+    function keyringPolicyId() external view returns (uint256);
 
     /// @notice Submits a `newTimelock`.
     /// @dev Warning: Reverts if a timelock is already pending. Revoke the pending timelock to overwrite it.
@@ -173,6 +179,9 @@ interface IMetaMorphoBase {
     /// @dev A supply in a reallocation step will make the reallocation revert if the amount is greater than the net
     /// amount from previous steps (i.e. total withdrawn minus total supplied).
     function reallocate(MarketAllocation[] calldata allocations) external;
+
+    /// @notice Sets the keyring checker and policy ID.
+    function setKeyringConfig(IKeyringChecker newKeyringChecker, uint256 newKeyringPolicyId) external;
 }
 
 /// @dev This interface is inherited by MetaMorpho so that function signatures are checked by the compiler.

--- a/src/libraries/ErrorsLib.sol
+++ b/src/libraries/ErrorsLib.sol
@@ -69,6 +69,9 @@ library ErrorsLib {
     /// @notice Thrown when the requested liquidity cannot be withdrawn from Morpho.
     error NotEnoughLiquidity();
 
+    /// @notice Thrown when the user is not whitelisted by the keyring checker.
+    error NotKeyringWhitelisted();
+
     /// @notice Thrown when submitting a cap for a market which does not exist.
     error MarketNotCreated();
 

--- a/src/libraries/EventsLib.sol
+++ b/src/libraries/EventsLib.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 import {Id} from "../../lib/morpho-blue/src/interfaces/IMorpho.sol";
-
+import {IKeyringChecker} from "./../interfaces/IKeyringChecker.sol";
 import {PendingAddress} from "./PendingLib.sol";
 
 /// @title EventsLib
@@ -24,6 +24,9 @@ library EventsLib {
 
     /// @notice Emitted when a new `newFeeRecipient` is set.
     event SetFeeRecipient(address indexed newFeeRecipient);
+
+    /// @notice Emitted when a new keyring checker and policy ID are set.
+    event SetKeyringConfig(IKeyringChecker indexed newKeyringChecker, uint256 newKeyringPolicyId);
 
     /// @notice Emitted when a pending `newGuardian` is submitted.
     event SubmitGuardian(address indexed newGuardian);

--- a/test/forge/MetaMorphoKeyringConfig.t.sol
+++ b/test/forge/MetaMorphoKeyringConfig.t.sol
@@ -25,9 +25,9 @@ contract MetaMorphoSetKeyringConfigTest is InternalTest {
         uint256 policyId = 123;
 
         vm.expectEmit(true, true, false, true);
-        emit EventsLib.SetKeyringConfig(address(mockKeyringChecker), policyId);
+        emit EventsLib.SetKeyringConfig(mockKeyringChecker, policyId);
 
-        this.setKeyringConfig(address(mockKeyringChecker), policyId);
+        this.setKeyringConfig(mockKeyringChecker, policyId);
 
         vm.stopPrank();
     }
@@ -37,7 +37,7 @@ contract MetaMorphoSetKeyringConfigTest is InternalTest {
         vm.startPrank(nonOwner);
 
         vm.expectRevert(abi.encodeWithSignature("OwnableUnauthorizedAccount(address)", nonOwner));
-        this.setKeyringConfig(address(mockKeyringChecker), 123);
+        this.setKeyringConfig(mockKeyringChecker, 123);
 
         vm.stopPrank();
     }
@@ -48,9 +48,9 @@ contract MetaMorphoSetKeyringConfigTest is InternalTest {
         uint256 policyId = 123;
 
         vm.expectEmit(true, true, false, true);
-        emit EventsLib.SetKeyringConfig(address(0), policyId);
+        emit EventsLib.SetKeyringConfig(IKeyringChecker(address(0)), policyId);
 
-        this.setKeyringConfig(address(0), policyId);
+        this.setKeyringConfig(IKeyringChecker(address(0)), policyId);
 
         vm.stopPrank();
     }
@@ -60,16 +60,16 @@ contract MetaMorphoSetKeyringConfigTest is InternalTest {
 
         // First configuration
         uint256 firstPolicyId = 123;
-        this.setKeyringConfig(address(mockKeyringChecker), firstPolicyId);
+        this.setKeyringConfig(mockKeyringChecker, firstPolicyId);
 
         // Second configuration
         uint256 secondPolicyId = 456;
         MockKeyringChecker newMockChecker = new MockKeyringChecker();
 
         vm.expectEmit(true, true, false, true);
-        emit EventsLib.SetKeyringConfig(address(newMockChecker), secondPolicyId);
+        emit EventsLib.SetKeyringConfig(newMockChecker, secondPolicyId);
 
-        this.setKeyringConfig(address(newMockChecker), secondPolicyId);
+        this.setKeyringConfig(newMockChecker, secondPolicyId);
 
         vm.stopPrank();
     }

--- a/test/forge/MetaMorphoKeyringConfig.t.sol
+++ b/test/forge/MetaMorphoKeyringConfig.t.sol
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.21;
+
+import "./helpers/InternalTest.sol";
+import {IKeyringChecker} from "../../src/interfaces/IKeyringChecker.sol";
+import {EventsLib} from "../../src/libraries/EventsLib.sol";
+
+contract MockKeyringChecker is IKeyringChecker {
+    function checkCredential(uint256, address) external pure returns (bool) {
+        return true;
+    }
+}
+
+contract MetaMorphoSetKeyringConfigTest is InternalTest {
+    MockKeyringChecker public mockKeyringChecker;
+
+    function setUp() public override {
+        super.setUp();
+        mockKeyringChecker = new MockKeyringChecker();
+    }
+
+    function testSetKeyringConfig() public {
+        vm.startPrank(OWNER);
+
+        uint256 policyId = 123;
+
+        vm.expectEmit(true, true, false, true);
+        emit EventsLib.SetKeyringConfig(address(mockKeyringChecker), policyId);
+
+        this.setKeyringConfig(address(mockKeyringChecker), policyId);
+
+        vm.stopPrank();
+    }
+
+    function testSetKeyringConfigOnlyOwner() public {
+        address nonOwner = makeAddr("nonOwner");
+        vm.startPrank(nonOwner);
+
+        vm.expectRevert(abi.encodeWithSignature("OwnableUnauthorizedAccount(address)", nonOwner));
+        this.setKeyringConfig(address(mockKeyringChecker), 123);
+
+        vm.stopPrank();
+    }
+
+    function testSetKeyringConfigZeroAddress() public {
+        vm.startPrank(OWNER);
+
+        uint256 policyId = 123;
+
+        vm.expectEmit(true, true, false, true);
+        emit EventsLib.SetKeyringConfig(address(0), policyId);
+
+        this.setKeyringConfig(address(0), policyId);
+
+        vm.stopPrank();
+    }
+
+    function testSetKeyringConfigMultipleTimes() public {
+        vm.startPrank(OWNER);
+
+        // First configuration
+        uint256 firstPolicyId = 123;
+        this.setKeyringConfig(address(mockKeyringChecker), firstPolicyId);
+
+        // Second configuration
+        uint256 secondPolicyId = 456;
+        MockKeyringChecker newMockChecker = new MockKeyringChecker();
+
+        vm.expectEmit(true, true, false, true);
+        emit EventsLib.SetKeyringConfig(address(newMockChecker), secondPolicyId);
+
+        this.setKeyringConfig(address(newMockChecker), secondPolicyId);
+
+        vm.stopPrank();
+    }
+}

--- a/test/forge/MetaMorphoKeyringWhitelist.t.sol
+++ b/test/forge/MetaMorphoKeyringWhitelist.t.sol
@@ -49,7 +49,7 @@ contract MetaMorphoKeyringWhitelist is IntegrationTest {
 
         // Configure keyring on vault
         vm.prank(OWNER);
-        vault.setKeyringConfig(address(keyringChecker), POLICY_ID);
+        vault.setKeyringConfig(keyringChecker, POLICY_ID);
 
         // Set supply queue (following MarketTest pattern)
         Id[] memory supplyQueue = new Id[](1);

--- a/test/forge/MetaMorphoKeyringWhitelist.t.sol
+++ b/test/forge/MetaMorphoKeyringWhitelist.t.sol
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {UtilsLib} from "../../lib/morpho-blue/src/libraries/UtilsLib.sol";
+import {SharesMathLib} from "../../lib/morpho-blue/src/libraries/SharesMathLib.sol";
+
+import "./helpers/IntegrationTest.sol";
+import {IKeyringChecker} from "../../src/interfaces/IKeyringChecker.sol";
+import {ErrorsLib} from "../../src/libraries/ErrorsLib.sol";
+
+contract MockKeyringChecker is IKeyringChecker {
+    mapping(address => bool) public isWhitelisted;
+
+    function setWhitelisted(address user, bool status) external {
+        isWhitelisted[user] = status;
+    }
+
+    function checkCredential(uint256, address user) external view returns (bool) {
+        return isWhitelisted[user];
+    }
+}
+
+contract MetaMorphoKeyringWhitelist is IntegrationTest {
+    using MathLib for uint256;
+    using MarketParamsLib for MarketParams;
+    using MorphoLib for IMorpho;
+
+    MockKeyringChecker public keyringChecker;
+    uint256 public constant POLICY_ID = 1;
+    address public whitelistedUser;
+    address public nonWhitelistedUser;
+    uint256 public constant INITIAL_DEPOSIT = 1000e18;
+
+    function setUp() public override {
+        super.setUp();
+
+        // Setup market caps first (following MarketTest pattern)
+        _setCap(allMarkets[0], CAP);
+        _setCap(allMarkets[1], CAP);
+        _setCap(allMarkets[2], CAP);
+
+        // Setup users
+        whitelistedUser = makeAddr("whitelistedUser");
+        nonWhitelistedUser = makeAddr("nonWhitelistedUser");
+
+        // Setup keyring checker
+        keyringChecker = new MockKeyringChecker();
+        keyringChecker.setWhitelisted(whitelistedUser, true);
+
+        // Configure keyring on vault
+        vm.prank(OWNER);
+        vault.setKeyringConfig(address(keyringChecker), POLICY_ID);
+
+        // Set supply queue (following MarketTest pattern)
+        Id[] memory supplyQueue = new Id[](1);
+        supplyQueue[0] = allMarkets[0].id();
+
+        vm.prank(ALLOCATOR);
+        vault.setSupplyQueue(supplyQueue);
+    }
+
+    function test_whitelistedUserCanDeposit() public {
+        loanToken.setBalance(SUPPLIER, INITIAL_DEPOSIT);
+        vm.startPrank(SUPPLIER);
+        loanToken.approve(address(vault), type(uint256).max);
+        vault.deposit(INITIAL_DEPOSIT, whitelistedUser);
+        assertEq(vault.balanceOf(whitelistedUser), INITIAL_DEPOSIT);
+    }
+
+    function test_nonWhitelistedUserCannotDeposit() public {
+        loanToken.setBalance(SUPPLIER, INITIAL_DEPOSIT);
+        vm.startPrank(SUPPLIER);
+        loanToken.approve(address(vault), type(uint256).max);
+        vm.expectRevert(ErrorsLib.NotKeyringWhitelisted.selector);
+        vault.deposit(INITIAL_DEPOSIT, nonWhitelistedUser);
+    }
+
+    function test_whitelistedUserCanMint() public {
+        loanToken.setBalance(SUPPLIER, INITIAL_DEPOSIT);
+        vm.startPrank(SUPPLIER);
+        loanToken.approve(address(vault), type(uint256).max);
+        vault.mint(INITIAL_DEPOSIT, whitelistedUser);
+        assertEq(vault.balanceOf(whitelistedUser), INITIAL_DEPOSIT);
+    }
+
+    function test_nonWhitelistedUserCannotMint() public {
+        loanToken.setBalance(SUPPLIER, INITIAL_DEPOSIT);
+        vm.startPrank(SUPPLIER);
+        loanToken.approve(address(vault), type(uint256).max);
+        vm.expectRevert(ErrorsLib.NotKeyringWhitelisted.selector);
+        vault.mint(INITIAL_DEPOSIT, nonWhitelistedUser);
+    }
+
+    function test_whitelistedUserCanWithdraw() public {
+        // First deposit some tokens
+        loanToken.setBalance(SUPPLIER, INITIAL_DEPOSIT);
+        vm.startPrank(SUPPLIER);
+        loanToken.approve(address(vault), type(uint256).max);
+        vault.deposit(INITIAL_DEPOSIT, whitelistedUser);
+        vm.stopPrank();
+
+        // Now test withdrawal
+        vm.startPrank(whitelistedUser);
+        vault.withdraw(INITIAL_DEPOSIT, whitelistedUser, whitelistedUser);
+        assertEq(loanToken.balanceOf(whitelistedUser), INITIAL_DEPOSIT);
+    }
+
+    function test_nonWhitelistedUserCannotWithdraw() public {
+        // First deposit some tokens
+        loanToken.setBalance(SUPPLIER, INITIAL_DEPOSIT);
+        vm.startPrank(SUPPLIER);
+        loanToken.approve(address(vault), type(uint256).max);
+        vault.deposit(INITIAL_DEPOSIT, whitelistedUser);
+        vm.stopPrank();
+
+        // Now test withdrawal with non-whitelisted user
+        vm.startPrank(whitelistedUser);
+        vm.expectRevert(ErrorsLib.NotKeyringWhitelisted.selector);
+        vault.withdraw(INITIAL_DEPOSIT, nonWhitelistedUser, nonWhitelistedUser);
+    }
+
+    function test_whitelistedUserCanRedeem() public {
+        // First deposit some tokens
+        loanToken.setBalance(SUPPLIER, INITIAL_DEPOSIT);
+        vm.startPrank(SUPPLIER);
+        loanToken.approve(address(vault), type(uint256).max);
+        vault.deposit(INITIAL_DEPOSIT, whitelistedUser);
+        vm.stopPrank();
+
+        // Now test redemption
+        vm.startPrank(whitelistedUser);
+        vault.redeem(INITIAL_DEPOSIT, whitelistedUser, whitelistedUser);
+        assertEq(loanToken.balanceOf(whitelistedUser), INITIAL_DEPOSIT);
+    }
+
+    function test_nonWhitelistedUserCannotRedeem() public {
+        // First deposit some tokens
+        loanToken.setBalance(SUPPLIER, INITIAL_DEPOSIT);
+        vm.startPrank(SUPPLIER);
+        loanToken.approve(address(vault), type(uint256).max);
+        vault.deposit(INITIAL_DEPOSIT, whitelistedUser);
+        vm.stopPrank();
+
+        // Now test redemption with non-whitelisted user
+        vm.startPrank(whitelistedUser);
+        vm.expectRevert(ErrorsLib.NotKeyringWhitelisted.selector);
+        vault.redeem(INITIAL_DEPOSIT, nonWhitelistedUser, nonWhitelistedUser);
+    }
+}


### PR DESCRIPTION
## Context
Here is a proposal for discussion, to implement whitelisting system of Keyring Network.

The approach is to:
- Adding a modifier to the `deposit`/`mint`, `withdraw` & `redeem` functions to prevent users without credentials from interacting with the main functions.
- Making the address of the KeyringChecker and the PolicyId configurable by the owner of the vault.
- Not performing a credential check if the address of the KeyringChecker is set to address(0).

## Done
- [x] Added `IKeyringChecker` interface that defines the contract responsible for credential verification
- [x] Interface exposes `checkCredential(uint256 policyId, address user)` to verify if a user is whitelisted for a specific policy
- [x] Added `setKeyringConfig(address keyringChecker, uint256 policyId)` function to configure Keyring settings, restricted to owner
- [x] Validates user credentials before allowing deposits using `checkCredential`
- [x] Added tests for:
       - `setKeyringConfig` functions
       - all the guarded functions
